### PR TITLE
Update color type name to canvasColor

### DIFF
--- a/spec/1.0.md
+++ b/spec/1.0.md
@@ -88,7 +88,7 @@ Edges are lines that connect one node to another.
 
 ## Color
 
-The `color` type is used to encode color data for nodes and edges. Colors attributes expect a string. Colors can be specified in hex format, e.g. `"#FFFFFF"`. Six preset colors exist, mapped to the following numbers:
+The `canvasColor` type is used to encode color data for nodes and edges. Colors attributes expect a string. Colors can be specified in hex format, e.g. `"#FFFFFF"`. Six preset colors exist, mapped to the following numbers:
 
 - `1` red
 - `2` orange


### PR DESCRIPTION
In the node and edge definitions the type is called `canvasColor`, so if I understand the spec right, the Color section should also reference the type as `canvasColor` and not `color`. 

(the other alternative is just calling it `color` everywhere)