### PR TITLE
Added Python Library for JSON Canvas - PyJSONCanvas

### DIFF
--- a/docs/apps.md
+++ b/docs/apps.md
@@ -23,3 +23,4 @@ JSON Canvas is supported by the following apps and tools. If you would like to a
 - [TypeScript library](https://npmjs.com/package/@trbn/jsoncanvas)
 - [C single-header library](https://github.com/ossldossl/jsonCanvas)
 - [Go library](https://github.com/supersonicpineapple/go-jsoncanvas)
+- [Python library](https://pypi.org/project/PyJSONCanvas/)


### PR DESCRIPTION
Adds (JSON Canvas Python Library to the repo)[https://pypi.org/project/PyJSONCanvas/] to the apps.md file.