### PR TITLE
Add Grapher to the apps list

### DIFF
--- a/docs/apps.md
+++ b/docs/apps.md
@@ -11,6 +11,7 @@ JSON Canvas is supported by the following apps and tools. If you would like to a
 | [Flowchart Fun](https://flowchart.fun/)         |         |   ✓    |   ✓    |
 | [hi-canvas](https://hi-canvas.marknoteapp.com/) |         |   ✓    |   ✓    |
 | [OrgPad](https://orgpad.info/)                  |         |   ✓    |   ✓    |
+| [Grapher](https://grapherx.netlify.app/)        |         |        |   ✓    |
 
 ## Tools
 


### PR DESCRIPTION
Grapher (website: https://grapherx.netlify.app/ , repo: https://codeberg.org/nilesh/grapher ) now allows exporting files in the .canvas format. I have tested this by re-importing the file with hi-canvas.

Parent-child relationship between nodes gets lost as the jsoncanvas spec is not currently clear about how grouping or nesting is to be represented.