### PR TITLE
Add "TypeScript viewer library" to Libraries list

### DIFF
--- a/docs/apps.md
+++ b/docs/apps.md
@@ -35,3 +35,4 @@ To convert from JSON Canvas to other formats:
 - [TypeScript library](https://npmjs.com/package/@trbn/jsoncanvas)
 - [Rehype Rendering Library (inline)](https://github.com/lovettbarron/rehype-jsoncanvas)
 - [Vue library](https://github.com/wujieli0207/vue-json-canvas)
+- [TypeScript viewer library](https://github.com/Hesprs/JSON-Canvas-Viewer)


### PR DESCRIPTION
Distinguished JSON Canvas Developers and Contributors:

I developed a TypeScript-based render & viewer for `JSON Canvas`, as a UI component that can be integrated into any web framework.

After googling around all the existing libraries, I found some are for particular frameworks, some are incomplete yet no longer updated, some manipulate `.canvas` data only. This library aims at providing full-featured displaying and interaction in browsers. It is now sufficiently developed, omni-framework and production-ready as an `npm` package.

This viewer is derived from [sofanati-nour/obsidian-canvas-web-renderer](https://github.com/sofanati-nour/obsidian-canvas-web-renderer), but is way more developed and optimized.

I'm looking forward earnestly to the inclusion of this library on the [JSON Canvas website](https://jsoncanvas.org/docs/apps/).

**Screenshot**:

![JSON Canvas Viewer](https://github.com/Hesprs/JSON-Canvas-Viewer/blob/main/example/preview.png?raw=true)

**Links**:
[GitHub](https://github.com/Hesprs/JSON-Canvas-Viewer) | [npm](https://www.npmjs.com/package/json-canvas-viewer) | [Demo](https://hesprs.github.io/canvas_demo)

Thanks,
Hēsperus on 15 Aug. 2025